### PR TITLE
opcode cesc1 0x01 (escnames routines) support

### DIFF
--- a/src/alis.c
+++ b/src/alis.c
@@ -68,6 +68,10 @@ void readexec_opcode(void) {
     readexec(opcodes, "opcode", 0);
 }
 
+void readexec_escname(void) {
+    readexec(escnames, "escname", 1);
+}
+
 void readexec_opername(void) {
     readexec(opernames, "opername", 1);
 }

--- a/src/alis_private.h
+++ b/src/alis_private.h
@@ -26,6 +26,7 @@
 #include "sys/sys.h"
 
 void readexec_opcode(void);
+void readexec_escname(void);
 void readexec_opername(void);
 void readexec_storename(void);
 void readexec_addname(void);
@@ -37,6 +38,7 @@ void readexec_opername_swap(void);
 void cstore_continue(void);
 
 extern sAlisOpcode  opcodes[];
+extern sAlisOpcode  escnames[];
 extern sAlisOpcode  opernames[];
 extern sAlisOpcode  storenames[];
 extern sAlisOpcode  addnames[];

--- a/src/opcodes.c
+++ b/src/opcodes.c
@@ -5604,17 +5604,19 @@ static void casleepoff(void) {
     set_0x24_scan_inter(alis.script->vram_org, get_0x24_scan_inter(alis.script->vram_org) | 4); // TODO check if byte ptr is OK: bts dword ptr es:[ebp-24h], 2
 }
 
+static void cesc1(void)     {
+//    u16 code = script_read8() | 0x100;
+//    sAlisOpcode opcode = opcodes[code];
+//    debug(EDebugInfo, " %s", opcode.name[0] == 0 ? "UNKNOWN" : opcode.name);
+//    return opcode.fptr();
+    readexec_escname();
+}
+
 // ============================================================================
 #pragma mark - Unimplemented opcodes
 // ============================================================================
 static void cnul(void)      {
     debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-static void cesc1(void)     {
-    u16 code = script_read8() | 0x100;
-    sAlisOpcode opcode = opcodes[code];
-    debug(EDebugInfo, " %s", opcode.name[0] == 0 ? "UNKNOWN" : opcode.name);
-    return opcode.fptr();
 }
 static void cesc2(void)     {
     debug(EDebugWarning, "MISSING: %s", __FUNCTION__);


### PR DESCRIPTION
For Robinson's Requiem (floppy and CD versions).
The escnames (codesc1) routines had already been coded (escnames.c), but could not be executed. Now they can be called and executed, which happens successfully.