### PR TITLE
Fix: Crash on quit if sound is played

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -73,15 +73,15 @@ int main(int argc, char *argv[]) {
             // Quit
             printf("\n");
             printf("#############################\n");
-            printf("# Releasing ALIS VM memory...\n");
-            printf("#############################\n");
-            alis_deinit();
-
-            printf("\n");
-            printf("#############################\n");
             printf("# System deinitialization...\n");
             printf("#############################\n");
             sys_deinit();
+
+            printf("\n");
+            printf("#############################\n");
+            printf("# Releasing ALIS VM memory...\n");
+            printf("#############################\n");
+            alis_deinit();
         }
         else {
             debug(EDebugFatal,

--- a/src/sys/sdl2/sys_sdl2.c
+++ b/src/sys/sdl2/sys_sdl2.c
@@ -470,15 +470,14 @@ void sys_render(pixelbuf_t buffer) {
     // TODO: yield for 60 fps ?
 }
 
-
-
 void sys_deinit(void) {
     
     SDL_PauseAudioDevice(_audio_id, 1);
     SDL_CloseAudioDevice(_audio_id);
 
     free(_audio_spec);
-    
+    SDL_Delay(20);   // 20ms fail-safe delay to make sure that sound buffer is empty
+
     PSG_delete(_psg);
 
     SDL_RemoveTimer(_timerID);


### PR DESCRIPTION
Crash on quit (by user event) if sound is played, caused by reading alis.mem in sys_audio_callback() when it is already released in alis_deinit().
- 20ms fail-safe delay in sys_deinit() to make sure that sound buffer is empty
- freeing alis memory in alis_deinit() after stopping audio in sys_deinit()