### PR TITLE
N/I indication + descriptions; some opcodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 endif()
 
 # SDL2
+# If SDL2 package is not found and cannot be installed for any reason, a quick fix can be made:
+#    place the devel-version of SDL2 (https://github.com/libsdl-org/SDL/releases) in the src/SDL2 folder
+#    (make sure the cmake folder is available in the package extracted to the src/SDL2 folder)
+#    and enable the following command:
+# set(SDL2_DIR "src/SDL2/cmake")
 find_package(SDL2 REQUIRED)
 
 include_directories(src/emu2149)
@@ -25,7 +30,7 @@ add_executable(alis
                src/main.c
                src/addnames.c src/alis.c src/channel.c src/debug.c src/escnames.c src/image.c 
                src/opcodes.c src/opernames.c src/platform.c src/screen.c src/video.c
-               src/script.c src/storenames.c src/unpack.c src/utils.c src/newalis.c)
+               src/script.c src/storenames.c src/unpack.c src/utils.c src/newalis.c src/export.c)
 
 target_link_libraries(alis m)
 target_link_libraries(alis ${SDL2_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ALIS
 
-An attempt to reimplement the virtual machine made by the [Silmarils](https://en.wikipedia.org/wiki/Silmarils_(company)) videogame company. The name of this repo comes from [this interview](https://www.atarilegend.com/interviews/26).
+An attempt to reimplement the virtual machine (VM) known as ALIS (Actor Language Integrated System), created by the [Silmarils](https://en.wikipedia.org/wiki/Silmarils_(company)) videogame company. The name of the machine is revealed in [this interview](https://www.atarilegend.com/interviews/26), and gave its name to this repo.
 
 ## Build and run
 
-Tested on macOS, Ubuntu and Windows.
+Tested on macOS, Ubuntu and Windows (Cygwin and MinGW).
 
 Install the following packages on your system:
 
@@ -32,6 +32,8 @@ Run the executable by passing the data path:
 ```bash
 ./alis data_path
 ```
+
+Run the executable without arguments for full usage options.
 
 ## More info...
 
@@ -67,8 +69,9 @@ Run the executable by passing the data path:
 | Arabian Nights          | ${\textsf{\small\color{gray}Not \ Working}}$ | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   |
 | Les Visiteurs           | ${\textsf{\small\color{gray}Not \ Working}}$ | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\small\color{gray}Not \ Working}}$ | ${\textsf{\color{gray}-}}$                   |
 | Inspector Gadget        | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\color{gray}-}}$                   | ${\textsf{\small\color{gray}Not \ Working}}$ |
-* Manhattan Dealers released as Operation: Cleanstreets by Brøderbund Software, Inc. in North America (PC, Amiga and Atari ST); Transarctica released as Arctic Baron in North America (PC only).
+* Note: Manhattan Dealers released as Operation: Cleanstreets by Brøderbund Software, Inc. in North America (PC, Amiga and Atari ST); Transarctica released as Arctic Baron in North America (PC only).
 
+Interpretation:
 - Not Working, main script is not executed at all.               
 - Broken, game is executed but crashes or freezes shortly after execution.               
 - Bugged, partially playable, game breaking bugs are to be expected.
@@ -86,7 +89,7 @@ Run the executable by passing the data path:
 
 ### Virtual Machine
 
-On a Silmarils game disk, you'll find the main executable (the VM), and several compressed game files. These games files contain almost all of the game mechanics, the assets (sounds, graphics, messages, etc...), as well as the VM's code in a proprietary pseudo-assembly format.
+On a Silmarils game disk, you'll find the main executable (the VM or the interpreter), and several compressed game files. These games files contain almost all of the game mechanics, the assets (sounds, graphics, messages, etc...), as well as the VM's code in a proprietary pseudo-assembly format.
 
 The main executable contains:
 - all the system calls, that depend on the target's architecture

--- a/TODO
+++ b/TODO
@@ -3,7 +3,7 @@ Todo list
 
 #############################################
  Started 2024-01-25
- Updated 2024-10-13
+ Updated 2024-10-14
 
  - not solved/not implemented
  + solved/implemented
@@ -23,9 +23,14 @@ Todo list
 + 2024-02-14: 2024-02-18: update mouse cursor whenever palette changes
 + 2024-03-06: 2024-03-09: use platform resolution instead of hardcoded 320 x 200
 + 2024-09-22: 2024-10-04: SDL2: SDL_OpenAudio may return an unsupported configuration. Conversion required. Github Issue #11.
++ 2024-09-28: 2024-10-13: Debug/Reports: A runtime Disalis (analog of disassembler for Alis script) for Alis VM (command line option -d). Pull requests #20, #22, #29.
+- 2024-09-28: Debug/Reports: Built-in Disalis of Alis script files.
 - 2024-10-11: Capturing screenshots. There are several possible implementations here, depending on the task for which the screenshot is taken. Capturing a texture, surface or window. On Mac/Windows with or without window title and border. With or without a cursor. All of these options may be needed for different user tasks.
 - 2024-10-11: Improvement: GET_PTR() preprocessor function or macro to replace 'alis.mem + offset' in code to avoid crashing when executing a broken script if it tries to access unallocated memory.
 - 2024-10-12: Windows issue: Unicode in filenames is not supported when compiling under Windows (MinGW). Running games is not affected by this issue, but a folder with game files must have a supported character set in its name. This problem does not apply when compiling under Cygwin.
+- 2024-10-12: Debug/Reports: Built-in util to unpack Alis script files (unpack mode). Based on and is an updated and reworked version of silm-depack util by Maestun (https://github.com/maestun/silm-depack). Pull requests #29.
+- 2024-10-13: Debug/Reports: Built-in util to extract resources (text, audio, sample, music, image and video resources) from Alis script files (extract/resource mode). Based on and is an updated and reworked version of silm-extract by Skruug (https://github.com/skruug/silm-extract).
+- 2024-10-14: Debug/Reports: Built-in util to extract doc-check words.
 
 #############################################
   2. Games list:

--- a/TODO
+++ b/TODO
@@ -29,7 +29,7 @@ Todo list
 - 2024-10-11: Improvement: GET_PTR() preprocessor function or macro to replace 'alis.mem + offset' in code to avoid crashing when executing a broken script if it tries to access unallocated memory.
 - 2024-10-12: Windows issue: Unicode in filenames is not supported when compiling under Windows (MinGW). Running games is not affected by this issue, but a folder with game files must have a supported character set in its name. This problem does not apply when compiling under Cygwin.
 - 2024-10-12: Debug/Reports: Built-in util to unpack Alis script files (unpack mode). Based on and is an updated and reworked version of silm-depack util by Maestun (https://github.com/maestun/silm-depack). Pull requests #29.
-- 2024-10-13: Debug/Reports: Built-in util to extract resources (text, audio, sample, music, image and video resources) from Alis script files (extract/resource mode). Based on and is an updated and reworked version of silm-extract by Skruug (https://github.com/skruug/silm-extract).
+- 2024-10-13: Debug/Reports: Built-in util to extract resources (text, audio, sample, music, image and video resources) from Alis script files (extract/resource mode). Based on and is an updated and reworked version of silm-extract by Skruug (https://github.com/skruug/silm-extract). Two extraction options: in the original internal Silmarils audio, image and video formats (raw data) and in converted form (bmp, wav, etc.).
 - 2024-10-14: Debug/Reports: Built-in util to extract doc-check words.
 
 #############################################

--- a/src/addnames.c
+++ b/src/addnames.c
@@ -222,11 +222,11 @@ static void aeval(void) {
 #pragma mark - Add routines pointer table
 // ============================================================================
 sAlisOpcode addnames[] = {
-    DECL_OPCODE(0x00, pnul,         "null pointer"),
+    DECL_OPCODE(0x00, pnul,         "[N/I] null pointer"),
     {},
-    DECL_OPCODE(0x02, pnul,         "null pointer"),
+    DECL_OPCODE(0x02, pnul,         "[N/I] null pointer"),
     {},
-    DECL_OPCODE(0x04, pnul,         "null pointer"),
+    DECL_OPCODE(0x04, pnul,         "[N/I] null pointer"),
     {},
     DECL_OPCODE(0x06, alocb,        "reads word (offset) from script, adds byte from d7 to byte at (vram+offset)"),
     {},

--- a/src/alis.c
+++ b/src/alis.c
@@ -347,8 +347,8 @@ void alis_init(sPlatform platform) {
     image.logy2 = alis.platform.height - 1;
 
     // NOTE: cswitching is never called for older games
-    // TODO: check other PC games like Ishar 3, maybe it is always 0
-    if (alis.platform.kind == EPlatformPC && ((alis.platform.uid == EGameRobinsonsRequiem0) || (alis.platform.uid == EGameRobinsonsRequiem1)))
+    // TODO: check other PC games. Robinson's Requiem, Storm Master (IBM PC): fswitch = 0
+    if (alis.platform.kind == EPlatformPC)
     {
       alis.fswitch = 0;
     } else

--- a/src/alis.c
+++ b/src/alis.c
@@ -129,11 +129,13 @@ void readexec_addname_swap(void) {
     readexec_addname();
 }
 
+// gparam
 void readexec_opername_saveD7(void) {
     alis.varD6 = alis.varD7;
     readexec_opername();
 }
 
+// gparam1
 void readexec_opername_saveD6(void) {
     
     s16 tmp = alis.varD7;
@@ -345,7 +347,14 @@ void alis_init(sPlatform platform) {
     image.logy2 = alis.platform.height - 1;
 
     // NOTE: cswitching is never called for older games
-    alis.fswitch = 1;
+    // TODO: check other PC games like Ishar 3, maybe it is always 0
+    if (alis.platform.kind == EPlatformPC && ((alis.platform.uid == EGameRobinsonsRequiem0) || (alis.platform.uid == EGameRobinsonsRequiem1)))
+    {
+      alis.fswitch = 0;
+    } else
+    {
+      alis.fswitch = 1;
+    }
     alis.flagmain = 0;
     
     alis.fallent = 0;

--- a/src/alis.h
+++ b/src/alis.h
@@ -217,6 +217,8 @@ typedef struct {
     u8 *            desmouse;
     
     s16             prevkey;
+
+    s16             theconfig;
     
     s16             wcx;
     s16             wcy;
@@ -287,6 +289,8 @@ typedef struct {
     sRawBlock       blocks[1024];
     
     u8              charmode;
+    u8              xlocate;
+    u8              ylocate;
     
     // font
     u16             foasc;

--- a/src/config.h
+++ b/src/config.h
@@ -39,7 +39,7 @@
 #include <sys/types.h>
 
 #define kProgName           "alis"
-#define kProgVersion        "0.1.029" // temporal version numbering scheme: x.y.zzz; zzz - pull request number
+#define kProgVersion        "0.1.030" // temporal version numbering scheme: x.y.zzz; zzz - pull request number
 #define kPathMaxLen         (256)
 #define kNameMaxLen         (16)
 #define kDescMaxLen         (1024)

--- a/src/escnames.c
+++ b/src/escnames.c
@@ -122,13 +122,13 @@ void copenfilm(void) {
 #pragma mark - Codesc1 routines pointer table
 // ============================================================================
 sAlisOpcode codesc1names[] = {
-    DECL_OPCODE(0x00, cnul,         "null"),
-    DECL_OPCODE(0x01, csoundon,     "TODO: add desc"),
-    DECL_OPCODE(0x02, csoundoff,    "TODO: add desc"),
-    DECL_OPCODE(0x03, cmusicon,     "TODO: add desc"),
-    DECL_OPCODE(0x04, cmusicoff,    "TODO: add desc"),
-    DECL_OPCODE(0x05, cdelfilm,     "TODO: add desc"),
-    DECL_OPCODE(0x06, copenfilm,    "TODO: add desc")
+    DECL_OPCODE(0x00, cnul,         "[N/I] null"),
+    DECL_OPCODE(0x01, csoundon,     "sound on"),
+    DECL_OPCODE(0x02, csoundoff,    "sound off"),
+    DECL_OPCODE(0x03, cmusicon,     "music on"),
+    DECL_OPCODE(0x04, cmusicoff,    "music off"),
+    DECL_OPCODE(0x05, cdelfilm,     "close and delete video from memory"),
+    DECL_OPCODE(0x06, copenfilm,    "open video")
 };
 
 // ============================================================================

--- a/src/newalis.c
+++ b/src/newalis.c
@@ -257,17 +257,17 @@ static void cesc1(void) {
 
 // Codopname no. 003 opcode 0x02 cesc2
 static void cesc2(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 004 opcode 0x03 cesc3
 static void cesc3(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 005 opcode 0x04 cbreakpt
 static void cbreakpt(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 006 opcode 0x05 cjsr8
@@ -302,12 +302,12 @@ static void cjmp24(void) {
 
 // Codopname no. 012 opcode 0x0b cjsrabs
 static void cjsrabs(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 013 opcode 0x0c cjmpabs
 static void cjmpabs(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 014 opcode 0x0d cjsrproc
@@ -330,7 +330,7 @@ static void cjmpproc(void) {
 
 // Codopname no. 017 opcode 0x10 cjmpind24
 static void cjmpind24(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 018 opcode 0x11 cret
@@ -420,12 +420,12 @@ static void csub(void) {
 
 // Codopname no. 035 opcode 0x22 cmul
 static void cmul(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 036 opcode 0x23 cdiv
 static void cdiv(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 037 opcode 0x24 cvprint
@@ -1354,7 +1354,7 @@ static void cengine(void) {
 
 // Codopname no. 213 opcode 0xd4 cautobase
 static void cautobase(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 214 opcode 0xd5 cwalkanim
@@ -1476,12 +1476,12 @@ static void cfreetab(void) {
 
 // Codopname no. 236 opcode 0xeb cscantab
 static void cscantab(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 237 opcode 0xec cneartab
 static void cneartab(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
 }
 
 // Codopname no. 238 opcode 0xed cnul
@@ -2900,11 +2900,11 @@ static void aeval(void) {
 #pragma mark - Opcode / Codop (Code-op) routines pointer table
 // ============================================================================
 sAlisOpcode opcodes_v40[] = {
-    DECL_OPCODE(0x00, cnul,         "null"),
+    DECL_OPCODE(0x00, cnul,         "[N/I] null"),
     DECL_OPCODE(0x01, cesc1,        "TODO: add desc"),
-    DECL_OPCODE(0x02, cesc2,        "TODO: add desc"),
-    DECL_OPCODE(0x03, cesc3,        "TODO: add desc"),
-    DECL_OPCODE(0x04, cbreakpt,     "TODO: add desc"),
+    DECL_OPCODE(0x02, cesc2,        "[N/I]"),
+    DECL_OPCODE(0x03, cesc3,        "[N/I]"),
+    DECL_OPCODE(0x04, cbreakpt,     "[N/I]"),
     DECL_OPCODE(0x05, cjsr8,        "jump to sub-routine with 8-bit offset"),
     DECL_OPCODE(0x06, cjsr16,       "jump to sub-routine with 16-bit offset"),
     DECL_OPCODE(0x07, cjsr24,       "jump to sub-routine with 24-bit offset"),
@@ -2939,10 +2939,10 @@ sAlisOpcode opcodes_v40[] = {
     DECL_OPCODE(0x24, cvprint,      "TODO: add desc"),
     DECL_OPCODE(0x25, csprinti,     "TODO: add desc"),
     DECL_OPCODE(0x26, csprinta,     "TODO: add desc"),
-    DECL_OPCODE(0x27, clocate,      "TODO: add desc"),
-    DECL_OPCODE(0x28, ctab,         "TODO: add desc"),
+    DECL_OPCODE(0x27, clocate,      "set cursor position x, y"),
+    DECL_OPCODE(0x28, ctab,         "tabulation, set cursor position x"),
     DECL_OPCODE(0x29, cdim,         "TODO: add desc"),
-    DECL_OPCODE(0x2a, cnul,         "TODO: add desc"),   // tcodop_2A: crandom => cnul
+    DECL_OPCODE(0x2a, cnul,         "[N/I] null"),       // tcodop_2A: crandom => cnul
     DECL_OPCODE(0x2b, cloop8,       "TODO: add desc"),
     DECL_OPCODE(0x2c, cloop16,      "TODO: add desc"),
     DECL_OPCODE(0x2d, cloop24,      "TODO: add desc"),
@@ -2952,7 +2952,7 @@ sAlisOpcode opcodes_v40[] = {
     DECL_OPCODE(0x31, cstart16,     "TODO: add desc"),
     DECL_OPCODE(0x32, cstart24,     "TODO: add desc"),
     DECL_OPCODE(0x33, cstartbase,   "TODO: add desc"),   // tcodop_33: cleave => cstartbase
-    DECL_OPCODE(0x34, cnul,         "TODO: add desc"),   // tcodop_34: cprotect => cnul
+    DECL_OPCODE(0x34, cnul,         "[N/I] null"),       // tcodop_34: cprotect => cnul
     DECL_OPCODE(0x35, casleep,      "TODO: add desc"),
     DECL_OPCODE(0x36, cclock,       "TODO: add desc"),
     DECL_OPCODE(0x37, canim,        "TODO: add desc"),   // tcodop_37: cnul => canim
@@ -2969,7 +2969,7 @@ sAlisOpcode opcodes_v40[] = {
     DECL_OPCODE(0x42, cstop,        "TODO: add desc"),
     DECL_OPCODE(0x43, cvecdistabs,  "TODO: add desc"),   // tcodop_43: cstopret => cvecdistabs
     DECL_OPCODE(0x44, cexit,        "TODO: add desc"),
-    DECL_OPCODE(0x45, cload,        "Load and unpack a script, set into vm"),
+    DECL_OPCODE(0x45, cload,        "load and unpack a script, set into vm"),
     DECL_OPCODE(0x46, csctype,      "TODO: add desc"),   // tcodop_46: cdefsc => csctype
     DECL_OPCODE(0x47, cscreen,      "TODO: add desc"),
     DECL_OPCODE(0x48, cput,         "TODO: add desc"),
@@ -2980,7 +2980,7 @@ sAlisOpcode opcodes_v40[] = {
     DECL_OPCODE(0x4d, cmov,         "TODO: add desc"),
     DECL_OPCODE(0x4e, copensc,      "TODO: add desc"),
     DECL_OPCODE(0x4f, cclosesc,     "TODO: add desc"),
-    DECL_OPCODE(0x50, cnul,         "TODO: add desc"),   // tcodop_50: cerasall => cnul
+    DECL_OPCODE(0x50, cnul,         "[N/I] null"),       // tcodop_50: cerasall => cnul
     DECL_OPCODE(0x51, caddput,      "TODO: add desc"),   // tcodop_51: cforme => caddput
     DECL_OPCODE(0x52, caddputat,    "TODO: add desc"),   // tcodop_52: cdelforme => caddputat
     DECL_OPCODE(0x53, ctstmov,      "TODO: add desc"),
@@ -3039,7 +3039,7 @@ sAlisOpcode opcodes_v40[] = {
     DECL_OPCODE(0x88, csetmouse,    "set mouse position"),
     DECL_OPCODE(0x89, cobjaset,     "TODO: add desc"),   // tcodop_89: cdefvect => cobjaset
     DECL_OPCODE(0x8a, cobjamov,     "TODO: add desc"),   // tcodop_8A: csetvect => cobjamov
-    DECL_OPCODE(0x8b, cnul,         "null"),
+    DECL_OPCODE(0x8b, cnul,         "[N/I] null"),
     DECL_OPCODE(0x8c, ctsthit,      "TODO: add desc"),   // tcodop_8C: capproach => ctsthit
     DECL_OPCODE(0x8d, cftsthit,     "TODO: add desc"),   // tcodop_8D: cescape => cftsthit
     DECL_OPCODE(0x8e, cvtstmov,     "TODO: add desc"),
@@ -3112,7 +3112,7 @@ sAlisOpcode opcodes_v40[] = {
     DECL_OPCODE(0xd1, cbackstar,    "TODO: add desc"),
     DECL_OPCODE(0xd2, cstarring,    "TODO: add desc"),
     DECL_OPCODE(0xd3, cengine,      "TODO: add desc"),
-    DECL_OPCODE(0xd4, cautobase,    "TODO: add desc"),
+    DECL_OPCODE(0xd4, cautobase,    "[N/I]"),
     DECL_OPCODE(0xd5, cwalkanim,    "TODO: add desc"),   // tcodop_D5: cquality => cwalkanim
     DECL_OPCODE(0xd6, cfwalkanim,   "TODO: add desc"),   // tcodop_D6: chsprite => cfwalkanim
     DECL_OPCODE(0xd7, cselpalet,    "TODO: add desc"),
@@ -3126,7 +3126,7 @@ sAlisOpcode opcodes_v40[] = {
     DECL_OPCODE(0xdf, cscback,      "TODO: add desc"),
     DECL_OPCODE(0xe0, cscrolpage,   "TODO: add desc"),
     DECL_OPCODE(0xe1, cmatent,      "TODO: add desc"),
-    DECL_OPCODE(0xe2, cshrink,      "Delete bitmap and shift following data"),
+    DECL_OPCODE(0xe2, cshrink,      "delete bitmap and shift following data"),
     DECL_OPCODE(0xe3, cdefmap,      "TODO: add desc"),
     DECL_OPCODE(0xe4, csetmap,      "TODO: add desc"),
     DECL_OPCODE(0xe5, cputmap,      "TODO: add desc"),
@@ -3135,9 +3135,9 @@ sAlisOpcode opcodes_v40[] = {
     DECL_OPCODE(0xe8, cfwalk,       "TODO: add desc"),   // tcodop_E8: ctexmap => cfwalk
     DECL_OPCODE(0xe9, calloctab,    "TODO: add desc"),
     DECL_OPCODE(0xea, cfreetab,     "TODO: add desc"),
-    DECL_OPCODE(0xeb, cscantab,     "TODO: add desc"),
-    DECL_OPCODE(0xec, cneartab,     "TODO: add desc"),
-    DECL_OPCODE(0xed, cnul,         "TODO: add desc"),   // tcodop_ED: cscsun => cnul ; cobjcycle
+    DECL_OPCODE(0xeb, cscantab,     "[N/I]"),
+    DECL_OPCODE(0xec, cneartab,     "[N/I]"),
+    DECL_OPCODE(0xed, cnul,         "[N/I] null"),       // tcodop_ED: cscsun => cnul ; cobjcycle
     DECL_OPCODE(0xee, cdarkpal,     "TODO: add desc"),
     DECL_OPCODE(0xef, cscshade,     "TODO: add desc"),   // tcodop_EF: cscdark => cscshade
     DECL_OPCODE(0xf0, caset,        "TODO: add desc"),
@@ -3162,13 +3162,13 @@ sAlisOpcode opcodes_v40[] = {
 #pragma mark - Codesc1 routines pointer table
 // ============================================================================
 sAlisOpcode codesc1names_v40[] = {
-    DECL_OPCODE(0x00, cnul,         "null"),
-    DECL_OPCODE(0x01, csoundon,     "TODO: add desc"),
-    DECL_OPCODE(0x02, csoundoff,    "TODO: add desc"),
-    DECL_OPCODE(0x03, cmusicon,     "TODO: add desc"),
-    DECL_OPCODE(0x04, cmusicoff,    "TODO: add desc"),
-    DECL_OPCODE(0x05, cdelfilm,     "TODO: add desc"),
-    DECL_OPCODE(0x06, copenfilm,    "TODO: add desc"),
+    DECL_OPCODE(0x00, cnul,         "[N/I] null"),
+    DECL_OPCODE(0x01, csoundon,     "sound on"),
+    DECL_OPCODE(0x02, csoundoff,    "sound off"),
+    DECL_OPCODE(0x03, cmusicon,     "music on"),
+    DECL_OPCODE(0x04, cmusicoff,    "music off"),
+    DECL_OPCODE(0x05, cdelfilm,     "close and delete video from memory"),
+    DECL_OPCODE(0x06, copenfilm,    "open video"),
     DECL_OPCODE(0x07, cdeffont,     "TODO: add desc"),   // tcodesc1_07: + cdeffont
     DECL_OPCODE(0x08, cloadtext,    "TODO: add desc"),   // tcodesc1_08: + cloadtext
     DECL_OPCODE(0x09, cafteron,     "TODO: add desc"),   // tcodesc1_09: + cafteron
@@ -3182,7 +3182,7 @@ sAlisOpcode codesc1names_v40[] = {
     DECL_OPCODE(0x11, cvideo,       "TODO: add desc"),   // tcodesc1_11: + cvideo
     DECL_OPCODE(0x12, ctexture,     "TODO: add desc"),   // tcodesc1_12: + ctexture
     DECL_OPCODE(0x13, cplaycd,      "TODO: add desc"),   // tcodesc1_13: + cplaycd
-    DECL_OPCODE(0x14, cnul,         "TODO: add desc"),   // tcodesc1_14: + cnul
+    DECL_OPCODE(0x14, cnul,         "[N/I] null"),       // tcodesc1_14: + cnul
     DECL_OPCODE(0x15, cobjtrans,    "TODO: add desc"),   // tcodesc1_15: + cobjtrans
     DECL_OPCODE(0x16, conscreen,    "TODO: add desc"),   // tcodesc1_16: + conscreen
     DECL_OPCODE(0x17, cgetglobal,   "TODO: add desc"),   // tcodesc1_17: + cgetglobal
@@ -3190,8 +3190,8 @@ sAlisOpcode codesc1names_v40[] = {
     DECL_OPCODE(0x19, cmatitem,     "TODO: add desc"),   // tcodesc1_19: + cmatitem
     DECL_OPCODE(0x1a, cmaskitem,    "TODO: add desc"),   // tcodesc1_1A: + cmaskitem
     DECL_OPCODE(0x1b, cdefitem,     "TODO: add desc"),   // tcodesc1_1B: + cdefitem
-    DECL_OPCODE(0x1c, cnul,         "TODO: add desc"),   // tcodesc1_1C: + cnul
-    DECL_OPCODE(0x1d, cnul,         "TODO: add desc"),   // tcodesc1_1D: + cnul
+    DECL_OPCODE(0x1c, cnul,         "[N/I] null"),       // tcodesc1_1C: + cnul
+    DECL_OPCODE(0x1d, cnul,         "[N/I] null"),       // tcodesc1_1D: + cnul
     DECL_OPCODE(0x1e, cgetmap,      "TODO: add desc"),   // tcodesc1_1E: + cgetmap
     DECL_OPCODE(0x1f, cconvmap,     "TODO: add desc"),   // tcodesc1_1F: + cconvmap
     DECL_OPCODE(0x20, csetfilm,     "TODO: add desc"),   // tcodesc1_20: + csetfilm
@@ -3237,7 +3237,7 @@ sAlisOpcode codesc1names_v40[] = {
     DECL_OPCODE(0x48, cvram,        "TODO: add desc"),   // tcodesc1_48: + cvram
     DECL_OPCODE(0x49, cadresnet,    "TODO: add desc"),   // tcodesc1_49: + cadresnet
     DECL_OPCODE(0x4a, cfdir,        "TODO: add desc"),   // tcodesc1_4A: + cfdir
-    DECL_OPCODE(0x4b, cnul,         "TODO: add desc"),   // tcodesc1_4B: + cnul ; entitem
+    DECL_OPCODE(0x4b, cnul,         "[N/I] null"),       // tcodesc1_4B: + cnul ; entitem
     DECL_OPCODE(0x4c, cloadas,      "TODO: add desc"),   // tcodesc1_4C: + cloadas
     DECL_OPCODE(0x4d, cfindobjitem, "TODO: add desc"),   // tcodesc1_4D: + cfindobjitem
     DECL_OPCODE(0x4e, cobjid,       "TODO: add desc"),   // tcodesc1_4E: + cobjid
@@ -3462,11 +3462,11 @@ sAlisOpcode opernames_v40[] = {
 #pragma mark - Store routines pointer table
 // ============================================================================
 sAlisOpcode storenames_v40[] = {
-    DECL_OPCODE(0x00, pnul,         "null pointer"),
+    DECL_OPCODE(0x00, pnul,         "[N/I] null pointer"),
     {},
-    DECL_OPCODE(0x02, pnul,         "null pointer"),
+    DECL_OPCODE(0x02, pnul,         "[N/I] null pointer"),
     {},
-    DECL_OPCODE(0x04, pnul,         "null pointer"),
+    DECL_OPCODE(0x04, pnul,         "[N/I] null pointer"),
     {},
     DECL_OPCODE(0x06, slocb,        "store byte from r7 at virtual ram location"),
     {},
@@ -3528,11 +3528,11 @@ sAlisOpcode storenames_v40[] = {
 #pragma mark - Add routines pointer table
 // ============================================================================
 sAlisOpcode addnames_v40[] = {
-    DECL_OPCODE(0x00, pnul,         "null pointer"),
+    DECL_OPCODE(0x00, pnul,         "[N/I] null pointer"),
     {},
-    DECL_OPCODE(0x02, pnul,         "null pointer"),
+    DECL_OPCODE(0x02, pnul,         "[N/I] null pointer"),
     {},
-    DECL_OPCODE(0x04, pnul,         "null pointer"),
+    DECL_OPCODE(0x04, pnul,         "[N/I] null pointer"),
     {},
     DECL_OPCODE(0x06, alocb,        "reads word (offset) from script, adds byte from d7 to byte at (vram+offset)"),
     {},

--- a/src/opcodes.c
+++ b/src/opcodes.c
@@ -302,6 +302,174 @@ static void cret(void);
 s32 io_malloc(s32 rawsize);
 void io_mfree(s32 addr);
 
+
+// ============================================================================
+#pragma mark - Stub routines
+// ============================================================================
+// Originally ALIS uses two types of stubs, and also has individual empty functions
+// (see the N/I section below on the latter).
+//
+// The address of the first stub, called cnul, is put in place of the missing (N/I)
+// functions (opcodes) in the pointer tables tcodop and tcodesc1.
+// It does nothing (the function cnul contain only retn).
+//
+// The address 0x0000 of the second stub, unnamed one (we called it pnul), is put in
+// place of the missing (N/I) functions (opcodes) in the pointer tables toper, tstore and tadd. 
+// It outputs a message that a null pointer has been called and then exits the program.
+//
+// As the engine evolved, opcodes that were sent to these stubs in earlier versions
+// could get their own implementation and even a new name in later ones and vice versa
+// (implemented functions could be removed from the engine, and pointers to cnul/pnul
+// were placed in their place in the corresponding tables).
+
+// Codopname no. 001 opcode 0x00 -> cnul
+// Codopname no. 056 opcode 0x37 -> cnul
+// Codopname no. 140 opcode 0x8b -> cnul
+// Codesc1name no. 01 opcode 0x00 -> cnul
+void cnul(void)      {
+    debug(EDebugWarning, "[N/I] cnul: NULL opcode called");
+}
+
+// Opername no. 31 opcode 0x3c -> pnul
+// Opername no. 32 opcode 0x3e -> pnul
+// Storename no. 01 opcode 0x00 -> pnul
+// Storename no. 02 opcode 0x02 -> pnul
+// Storename no. 03 opcode 0x04 -> pnul
+// Addname no. 01 opcode 0x00 -> pnul
+// Addname no. 02 opcode 0x02 -> pnul
+// Addname no. 03 opcode 0x04 -> pnul
+void pnul(void)      {
+    debug(EDebugFatal, "\n[N/I] pnul: NULL code pointer called\n");
+    if (!VM_IGNORE_ERRORS) {
+        debug(EDebugFatal, "The ALIS VM has been stopped.\n");
+        alis.running = 0;
+    }
+}
+
+// ============================================================================
+#pragma mark - Codesc1, Codesc2, Codesc3 routines
+// ============================================================================
+
+// Codopname no. 002 opcode 0x01 cesc1
+static void cesc1(void)     {
+    readexec_codesc1name();
+}
+
+// ============================================================================
+#pragma mark - Restored non-implemented [N/I] codops (opcodes)
+// ============================================================================
+// See next section for details on non-implemented opcodes
+// ============================================================================
+
+// Codopname no. 003 opcode 0x02 cesc2
+// The function is not yet found in ALIS interpreters (no confirmation that the codesc1 table
+// has been completed), restored for a reason. This does not affect the code if it does not exist.
+static void cesc2(void)     {
+    debug(EDebugWarning, "[N/I] CHECK: ", __FUNCTION__);
+    readexec_codesc2name();
+}
+
+// Codopname no. 004 opcode 0x03 cesc3
+// The function is not yet found in ALIS interpreters (no confirmation that tables codesc1 and codesc2
+// have been completed), restored for a reason. This does not affect the code if it does not exist.
+static void cesc3(void)     {
+    debug(EDebugWarning, "[N/I] CHECK: ", __FUNCTION__);
+    readexec_codesc3name();
+}
+
+// ============================================================================
+#pragma mark - Non-implemented [N/I] codops (opcodes)
+// ============================================================================
+// In the original interpreters, these opcodes are empty (their functions contain
+// only retn). If found, it should be documented in which game and on which platform
+// the implemented function is detected!
+//
+// As the engine evolved, opcodes that were empty in early versions could get
+// their implementation later and vice versa (become empty). This is observed even
+// in different versions of the same games, for example, on different platforms.
+//
+// Note: [N/I] functions are not to be confused with MISSING functions, whose
+// code is implemented in the original engine, but not yet implemented by us here.
+// ============================================================================
+
+// Codopname no. 005 opcode 0x04 cbreakpt
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cbreakpt(void)  {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
+// Codopname no. 012 opcode 0x0b cjsrabs
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cjsrabs(void)   {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
+// Codopname no. 013 opcode 0x0c cjmpabs
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cjmpabs(void)   {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
+// Codopname no. 014 opcode 0x0d cjsrind16
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cjsrind16(void) {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
+// Codopname no. 015 opcode 0x0e cjsrind24
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cjsrind24(void) {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
+// Codopname no. 016 opcode 0x0f cjmpind16
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cjmpind16(void) {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
+// Codopname no. 017 opcode 0x10 cjmpind24
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cjmpind24(void) {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
+// Codopname no. 035 opcode 0x22 cmul
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cmul(void)      {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
+// Codopname no. 036 opcode 0x23 cdiv
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cdiv(void)      {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
+// Codopname no. 202 opcode 0xc9 cscdump
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cscdump(void) {
+    debug(EDebugWarning, "[N/I] (NOP?): %s", __FUNCTION__);
+}
+
+// Codopname no. 213 opcode 0xd4 cautobase
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cautobase(void) {
+    debug(EDebugWarning, "[N/I] (NOP?): %s", __FUNCTION__);
+}
+
+// Codopname no. 236 opcode 0xeb cscantab
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cscantab(void) {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
+// Codopname no. 237 opcode 0xec cneartab
+// [N/I]: Robinson's Requiem (IBM PC)
+static void cneartab(void) {
+    debug(EDebugWarning, "[N/I]: %s", __FUNCTION__);
+}
+
 // ============================================================================
 #pragma mark - Opcode / Codop (Code-op) routines
 // ============================================================================
@@ -356,17 +524,23 @@ static void csprinta(void) {
 // Codopname no. 040 opcode 0x27 clocate
 static void clocate(void) {
     debug(EDebugWarning, "STUBBED: %s", __FUNCTION__);
-    
+    alis.charmode = 0;    
     readexec_opername_saveD7();
     readexec_opername_saveD6();
-    s16 xlocate = alis.varD7;
-    s16 ylocate = alis.varD6;
-//    io_locate();
+    alis.xlocate = (u8)(alis.varD7 & 0xff);
+    alis.ylocate = (u8)(alis.varD6 & 0xff);
+//  set cursor position in text mode: xlocate (new), ylocate (new), page = 0
+//  io_locate();
 }
 
 // Codopname no. 041 opcode 0x28 ctab
 static void ctab(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
+    debug(EDebugWarning, "STUBBED: %s", __FUNCTION__);
+    alis.charmode = 0;
+    readexec_opername_saveD7();
+    alis.xlocate = (u8)(alis.varD7 & 0xff);
+//  set tabulated cursor position in text mode: xlocate (new), ylocate (not changed), page = 0
+//  io_locate();
 }
 
 // Codopname no. 042 opcode 0x29 cdim
@@ -660,7 +834,12 @@ static void cclipping(void) {
 }
 
 // Codopname no. 060 opcode 0x3b cswitching
+// [N/I]: Robinson's Requiem (IBM PC)
 static void cswitching(void) {
+    if (alis.platform.kind == EPlatformPC && ((alis.platform.uid == EGameRobinsonsRequiem0) || (alis.platform.uid == EGameRobinsonsRequiem1))) {
+        debug(EDebugWarning, "[N/I] IBM PC: %s", __FUNCTION__);
+        return;
+    }
     alis.fswitch = 1;
 }
 
@@ -3697,11 +3876,6 @@ static void cscmap(void) {
     }
 }
 
-// Codopname no. 202 opcode 0xc9 cscdump
-static void cscdump(void) {
-    debug(EDebugInfo, "MISSING (NOP?): %s", __FUNCTION__);
-}
-
 // Codopname no. 203 opcode 0xca cfindcla
 static void cfindcla(void) {
     readexec_opername();
@@ -4002,16 +4176,16 @@ static void cstarring(void) {
 }
 
 // Codopname no. 212 opcode 0xd3 cengine
+// [N/I]: Robinson's Requiem (IBM PC)
 static void cengine(void) {
+    if (alis.platform.kind == EPlatformPC && ((alis.platform.uid == EGameRobinsonsRequiem0) || (alis.platform.uid == EGameRobinsonsRequiem1))) {
+        debug(EDebugWarning, "[N/I] IBM PC: %s", __FUNCTION__);
+        return;
+    }
     readexec_opername();
     readexec_opername();
     readexec_opername();
     readexec_opername();
-}
-
-// Codopname no. 213 opcode 0xd4 cautobase
-static void cautobase(void) {
-    debug(EDebugInfo, "MISSING (NOP?): %s", __FUNCTION__);
 }
 
 // Codopname no. 214 opcode 0xd5 cquality
@@ -4870,16 +5044,6 @@ static void calloctab(void) {
 
 // Codopname no. 235 opcode 0xea cfreetab
 static void cfreetab(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-// Codopname no. 236 opcode 0xeb cscantab
-static void cscantab(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-// Codopname no. 237 opcode 0xec cneartab
-static void cneartab(void) {
     debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
 }
 
@@ -5886,120 +6050,6 @@ static void cclock(void)    {
     set_0x3e_wait_time(alis.script->vram_org, alis.varD7 + alis.timeclock);
 }
 
-// Codopname no. 002 opcode 0x01 cesc1
-static void cesc1(void)     {
-//    u16 code = script_read8() | 0x100;
-//    sAlisOpcode opcode = opcodes[code];
-//    debug(EDebugInfo, " %s", opcode.name[0] == 0 ? "UNKNOWN" : opcode.name);
-//    return opcode.fptr();
-    readexec_codesc1name();
-}
-
-// Codopname no. 003 opcode 0x02 cesc2
-// The function is not yet found in ALIS interpreters (no confirmation that the codesc1 table
-// has been completed), restored for a reason. This does not affect the code if it does not exist.
-static void cesc2(void)     {
-    debug(EDebugWarning, "CHECK: ", __FUNCTION__);
-    readexec_codesc2name();
-}
-
-// Codopname no. 004 opcode 0x03 cesc3
-// The function is not yet found in ALIS interpreters (no confirmation that tables codesc1 and codesc2
-// have been completed), restored for a reason. This does not affect the code if it does not exist.
-static void cesc3(void)     {
-    debug(EDebugWarning, "CHECK: ", __FUNCTION__);
-    readexec_codesc3name();
-}
-
-// ============================================================================
-#pragma mark - Stub routines
-// ============================================================================
-
-// ALIS uses two types of stubs.
-// The first, called cnul, is put in place of missing functions (opcodes)
-// in tables tcodop and tcodesc1. It does nothing.
-//
-// The second, unnamed one (we called it pnul), has address 0x0000 and
-// is put in place of missing functions (opcodes) in tables toper, tstore and tadd.
-// It outputs a message that a null pointer has been called and then exits the program.
-//
-// As the engine evolved, opcodes that were sent to these stubs in earlier versions
-// could get their own implementation and a new name in later ones.
-
-// Codopname no. 001 opcode 0x00 -> cnul
-// Codopname no. 056 opcode 0x37 -> cnul
-// Codopname no. 140 opcode 0x8b -> cnul
-// Codesc1name no. 01 opcode 0x00 -> cnul
-void cnul(void)      {
-    debug(EDebugWarning, "WARNING: NULL opcode called");
-}
-
-// Opername no. 31 opcode 0x3c -> pnul
-// Opername no. 32 opcode 0x3e -> pnul
-// Storename no. 01 opcode 0x00 -> pnul
-// Storename no. 02 opcode 0x02 -> pnul
-// Storename no. 03 opcode 0x04 -> pnul
-// Addname no. 01 opcode 0x00 -> pnul
-// Addname no. 02 opcode 0x02 -> pnul
-// Addname no. 03 opcode 0x04 -> pnul
-void pnul(void)      {
-    debug(EDebugFatal, "\nERROR: NULL code pointer called\n");
-    if (!VM_IGNORE_ERRORS) {
-        debug(EDebugFatal, "The ALIS VM has been stopped.\n");
-        alis.running = 0;
-    }
-}
-
-// ============================================================================
-#pragma mark - Unimplemented codops
-// ============================================================================
-
-// Codopname no. 005 opcode 0x04 cbreakpt
-static void cbreakpt(void)  {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-// Codopname no. 035 opcode 0x22 cmul
-static void cmul(void)      {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-// Codopname no. 036 opcode 0x23 cdiv
-static void cdiv(void)      {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-// Codopname no. 012 opcode 0x0b cjsrabs
-static void cjsrabs(void)   {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-// Codopname no. 013 opcode 0x0c cjmpabs
-static void cjmpabs(void)   {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-// Codopname no. 014 opcode 0x0d cjsrind16
-static void cjsrind16(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-// Codopname no. 015 opcode 0x0e cjsrind24
-static void cjsrind24(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-// Codopname no. 016 opcode 0x0f cjmpind16
-static void cjmpind16(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-// Codopname no. 017 opcode 0x10 cjmpind24
-static void cjmpind24(void) {
-    debug(EDebugWarning, "MISSING: %s", __FUNCTION__);
-}
-
-
 // ============================================================================
 #pragma mark - Flow control - Subroutines
 // ============================================================================
@@ -6766,11 +6816,11 @@ void io_mfree(s32 addr)
 #pragma mark - Opcode / Codop (Code-op) routines pointer table (256 values)
 // ============================================================================
 sAlisOpcode opcodes[] = {
-    DECL_OPCODE(0x00, cnul,         "null"),
+    DECL_OPCODE(0x00, cnul,         "[N/I] null"),
     DECL_OPCODE(0x01, cesc1,        "TODO: add desc"),
-    DECL_OPCODE(0x02, cesc2,        "TODO: add desc"),
-    DECL_OPCODE(0x03, cesc3,        "TODO: add desc"),
-    DECL_OPCODE(0x04, cbreakpt,     "TODO: add desc"),
+    DECL_OPCODE(0x02, cesc2,        "[N/I]"),
+    DECL_OPCODE(0x03, cesc3,        "[N/I]"),
+    DECL_OPCODE(0x04, cbreakpt,     "[N/I]"),
     DECL_OPCODE(0x05, cjsr8,        "jump to sub-routine with 8-bit offset"),
     DECL_OPCODE(0x06, cjsr16,       "jump to sub-routine with 16-bit offset"),
     DECL_OPCODE(0x07, cjsr24,       "jump to sub-routine with 24-bit offset"),
@@ -6805,8 +6855,8 @@ sAlisOpcode opcodes[] = {
     DECL_OPCODE(0x24, cvprint,      "TODO: add desc"),
     DECL_OPCODE(0x25, csprinti,     "TODO: add desc"),
     DECL_OPCODE(0x26, csprinta,     "TODO: add desc"),
-    DECL_OPCODE(0x27, clocate,      "TODO: add desc"),
-    DECL_OPCODE(0x28, ctab,         "TODO: add desc"),
+    DECL_OPCODE(0x27, clocate,      "set cursor position x, y"),
+    DECL_OPCODE(0x28, ctab,         "tabulation, set cursor position x"),
     DECL_OPCODE(0x29, cdim,         "TODO: add desc"),
     DECL_OPCODE(0x2a, crandom,      "generate a random number"),
     DECL_OPCODE(0x2b, cloop8,       "TODO: add desc"),
@@ -6821,7 +6871,7 @@ sAlisOpcode opcodes[] = {
     DECL_OPCODE(0x34, cprotect,     "TODO: add desc"),
     DECL_OPCODE(0x35, casleep,      "TODO: add desc"),
     DECL_OPCODE(0x36, cclock,       "TODO: add desc"),
-    DECL_OPCODE(0x37, cnul,         "null"),
+    DECL_OPCODE(0x37, cnul,         "[N/I] null"),
     DECL_OPCODE(0x38, cscmov,       "TODO: add desc"),
     DECL_OPCODE(0x39, cscset,       "TODO: add desc"),
     DECL_OPCODE(0x3a, cclipping,    "TODO: add desc"),
@@ -6835,8 +6885,8 @@ sAlisOpcode opcodes[] = {
     DECL_OPCODE(0x42, cstop,        "TODO: add desc"),
     DECL_OPCODE(0x43, cstopret,     "TODO: add desc"),
     DECL_OPCODE(0x44, cexit,        "TODO: add desc"),
-    DECL_OPCODE(0x45, cload,        "Load and unpack a script, set into vm"),
-    DECL_OPCODE(0x46, cdefsc,       "Define Scene ??"),
+    DECL_OPCODE(0x45, cload,        "load and unpack a script, set into vm"),
+    DECL_OPCODE(0x46, cdefsc,       "define scene ??"),
     DECL_OPCODE(0x47, cscreen,      "TODO: add desc"),
     DECL_OPCODE(0x48, cput,         "TODO: add desc"),
     DECL_OPCODE(0x49, cputnat,      "TODO: add desc"),
@@ -6905,7 +6955,7 @@ sAlisOpcode opcodes[] = {
     DECL_OPCODE(0x88, csetmouse,    "set mouse position"),
     DECL_OPCODE(0x89, cdefvect,     "TODO: add desc"),
     DECL_OPCODE(0x8a, csetvect,     "TODO: add desc"),
-    DECL_OPCODE(0x8b, cnul,         "null"),
+    DECL_OPCODE(0x8b, cnul,         "[N/I] null"),
     DECL_OPCODE(0x8c, capproach,    "TODO: add desc"),
     DECL_OPCODE(0x8d, cescape,      "TODO: add desc"),
     DECL_OPCODE(0x8e, cvtstmov,     "TODO: add desc"),
@@ -6967,7 +7017,7 @@ sAlisOpcode opcodes[] = {
     DECL_OPCODE(0xc6, cscscale,     "TODO: add desc"),
     DECL_OPCODE(0xc7, creducing,    "TODO: add desc"),
     DECL_OPCODE(0xc8, cscmap,       "TODO: add desc"),
-    DECL_OPCODE(0xc9, cscdump,      "TODO: add desc"),
+    DECL_OPCODE(0xc9, cscdump,      "[N/I]"),
     DECL_OPCODE(0xca, cfindcla,     "TODO: add desc"),
     DECL_OPCODE(0xcb, cnearcla,     "TODO: add desc"),
     DECL_OPCODE(0xcc, cviewcla,     "TODO: add desc"),
@@ -6978,7 +7028,7 @@ sAlisOpcode opcodes[] = {
     DECL_OPCODE(0xd1, cbackstar,    "TODO: add desc"),
     DECL_OPCODE(0xd2, cstarring,    "TODO: add desc"),
     DECL_OPCODE(0xd3, cengine,      "TODO: add desc"),
-    DECL_OPCODE(0xd4, cautobase,    "TODO: add desc"),
+    DECL_OPCODE(0xd4, cautobase,    "[N/I]"),
     DECL_OPCODE(0xd5, cquality,     "TODO: add desc"),
     DECL_OPCODE(0xd6, chsprite,     "TODO: add desc"),
     DECL_OPCODE(0xd7, cselpalet,    "TODO: add desc"),
@@ -6992,7 +7042,7 @@ sAlisOpcode opcodes[] = {
     DECL_OPCODE(0xdf, cscback,      "TODO: add desc"),
     DECL_OPCODE(0xe0, cscrolpage,   "TODO: add desc"),
     DECL_OPCODE(0xe1, cmatent,      "TODO: add desc"),
-    DECL_OPCODE(0xe2, cshrink,      "Delete bitmap and shift following data"),
+    DECL_OPCODE(0xe2, cshrink,      "delete bitmap and shift following data"),
     DECL_OPCODE(0xe3, cdefmap,      "TODO: add desc"),
     DECL_OPCODE(0xe4, csetmap,      "TODO: add desc"),
     DECL_OPCODE(0xe5, cputmap,      "TODO: add desc"),
@@ -7001,8 +7051,8 @@ sAlisOpcode opcodes[] = {
     DECL_OPCODE(0xe8, ctexmap,      "TODO: add desc"),
     DECL_OPCODE(0xe9, calloctab,    "TODO: add desc"),
     DECL_OPCODE(0xea, cfreetab,     "TODO: add desc"),
-    DECL_OPCODE(0xeb, cscantab,     "TODO: add desc"),
-    DECL_OPCODE(0xec, cneartab,     "TODO: add desc"),
+    DECL_OPCODE(0xeb, cscantab,     "[N/I]"),
+    DECL_OPCODE(0xec, cneartab,     "[N/I]"),
     DECL_OPCODE(0xed, cscsun,       "TODO: add desc"),
     DECL_OPCODE(0xee, cdarkpal,     "TODO: add desc"),
     DECL_OPCODE(0xef, cscdark,      "TODO: add desc"),

--- a/src/opcodes.c
+++ b/src/opcodes.c
@@ -837,7 +837,7 @@ static void cclipping(void) {
 // [N/I]: Robinson's Requiem (IBM PC)
 static void cswitching(void) {
     if (alis.platform.kind == EPlatformPC && ((alis.platform.uid == EGameRobinsonsRequiem0) || (alis.platform.uid == EGameRobinsonsRequiem1))) {
-        debug(EDebugWarning, "[N/I] IBM PC: %s", __FUNCTION__);
+        debug(EDebugWarning, "[N/I] %s: %s", alis.platform.desc, __FUNCTION__);
         return;
     }
     alis.fswitch = 1;
@@ -4179,7 +4179,7 @@ static void cstarring(void) {
 // [N/I]: Robinson's Requiem (IBM PC)
 static void cengine(void) {
     if (alis.platform.kind == EPlatformPC && ((alis.platform.uid == EGameRobinsonsRequiem0) || (alis.platform.uid == EGameRobinsonsRequiem1))) {
-        debug(EDebugWarning, "[N/I] IBM PC: %s", __FUNCTION__);
+        debug(EDebugWarning, "[N/I] %s: %s", alis.platform.desc, __FUNCTION__);
         return;
     }
     readexec_opername();

--- a/src/opcodes.c
+++ b/src/opcodes.c
@@ -309,12 +309,12 @@ void io_mfree(s32 addr);
 // Originally ALIS uses two types of stubs, and also has individual empty functions
 // (see the N/I section below on the latter).
 //
-// The address of the first stub, called cnul, is put in place of the missing (N/I)
+// The address of the first stub, called cnul, is put in place of the non-implemented
 // functions (opcodes) in the pointer tables tcodop and tcodesc1.
 // It does nothing (the function cnul contain only retn).
 //
 // The address 0x0000 of the second stub, unnamed one (we called it pnul), is put in
-// place of the missing (N/I) functions (opcodes) in the pointer tables toper, tstore and tadd. 
+// place of the non-implemented functions (opcodes) in the pointer tables toper, tstore and tadd. 
 // It outputs a message that a null pointer has been called and then exits the program.
 //
 // As the engine evolved, opcodes that were sent to these stubs in earlier versions
@@ -388,7 +388,7 @@ static void cesc3(void)     {
 // their implementation later and vice versa (become empty). This is observed even
 // in different versions of the same games, for example, on different platforms.
 //
-// Note: [N/I] functions are not to be confused with MISSING functions, whose
+// Note: [N/I] functions are not to be confused with [MISSING] functions, whose
 // code is implemented in the original engine, but not yet implemented by us here.
 // ============================================================================
 
@@ -834,9 +834,9 @@ static void cclipping(void) {
 }
 
 // Codopname no. 060 opcode 0x3b cswitching
-// [N/I]: Robinson's Requiem (IBM PC)
+// [N/I]: Robinson's Requiem, Storm Master (IBM PC)
 static void cswitching(void) {
-    if (alis.platform.kind == EPlatformPC && ((alis.platform.uid == EGameRobinsonsRequiem0) || (alis.platform.uid == EGameRobinsonsRequiem1))) {
+    if (alis.platform.kind == EPlatformPC) {
         debug(EDebugWarning, "[N/I] %s: %s", alis.platform.desc, __FUNCTION__);
         return;
     }
@@ -4176,9 +4176,9 @@ static void cstarring(void) {
 }
 
 // Codopname no. 212 opcode 0xd3 cengine
-// [N/I]: Robinson's Requiem (IBM PC)
+// [N/I]: Robinson's Requiem, Ishar 3, Storm Master (IBM PC)
 static void cengine(void) {
-    if (alis.platform.kind == EPlatformPC && ((alis.platform.uid == EGameRobinsonsRequiem0) || (alis.platform.uid == EGameRobinsonsRequiem1))) {
+    if (alis.platform.kind == EPlatformPC) {
         debug(EDebugWarning, "[N/I] %s: %s", alis.platform.desc, __FUNCTION__);
         return;
     }

--- a/src/opernames.c
+++ b/src/opernames.c
@@ -867,6 +867,8 @@ void ojoykey(void) {
 // Opername no. 85 opcode 0xa8 oconfig
 void oconfig(void) {
     alis.varD7 = 0;
+//
+//    alis.varD7 = alis.theconfig;
 }
 
 // Opername no. 31 opcode 0x3c pnul
@@ -942,9 +944,9 @@ sAlisOpcode opernames[] = {
     {},
     DECL_OPCODE(0x3a, ofin,         "ends an expression evaluation loop"),
     {},
-    DECL_OPCODE(0x3c, pnul,         "null pointer"),
+    DECL_OPCODE(0x3c, pnul,         "[N/I] null pointer"),
     {},
-    DECL_OPCODE(0x3e, pnul,         "null pointer"),
+    DECL_OPCODE(0x3e, pnul,         "[N/I] null pointer"),
     {},
     DECL_OPCODE(0x40, opushacc,     "push word from r7 into virtual accumulator"),
     {},

--- a/src/storenames.c
+++ b/src/storenames.c
@@ -260,11 +260,11 @@ void cstore_continue(void) {
 //  jumps at the address (JTAB_OPERAMES + offset).
 // ============================================================================
 sAlisOpcode storenames[] = {
-    DECL_OPCODE(0x00, pnul,         "null pointer"),
+    DECL_OPCODE(0x00, pnul,         "[N/I] null pointer"),
     {},
-    DECL_OPCODE(0x02, pnul,         "null pointer"),
+    DECL_OPCODE(0x02, pnul,         "[N/I] null pointer"),
     {},
-    DECL_OPCODE(0x04, pnul,         "null pointer"),
+    DECL_OPCODE(0x04, pnul,         "[N/I] null pointer"),
     {},
     DECL_OPCODE(0x06, slocb,        "store byte from r7 at virtual ram location"),
     {},


### PR DESCRIPTION
* Updated Todo
* Added “export.c” for cmake
* N/I indication and differentiation with MISSING for all 5 tables (including five more tables in newalis)
* RRQ PC: fswitch = 0 on loading main
* RRQ PC: cswitching is N/I (fswitch is not set to 1)
* RRQ PC: cengine is N/I
* + variables xlocate, ylocate, theconfig
* opcodes clocate, ctab (with xlocate, ylocate)


